### PR TITLE
Bootstrap 3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gem 'sqlite3'
 # in production environments by default.
 gem 'sass-rails',   '~> 4.0.0'
 gem "compass-rails", "~> 2.0.alpha.0"
-gem 'bootstrap-sass-rails', '~> 2.3.2.1'
+gem 'bootstrap-sass-rails', '~> 3.0.0'
 
 # See https://github.com/sstephenson/execjs#readme for more supported runtimes
 # gem 'therubyracer', :platforms => :ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -33,7 +33,7 @@ GEM
       erubis (>= 2.6.6)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
-    bootstrap-sass-rails (2.3.2.1)
+    bootstrap-sass-rails (3.0.0.3)
       railties (>= 3.1.0)
       sass-rails (>= 3.1.0)
     builder (3.1.4)
@@ -242,7 +242,7 @@ PLATFORMS
 DEPENDENCIES
   better_errors
   binding_of_caller
-  bootstrap-sass-rails (~> 2.3.2.1)
+  bootstrap-sass-rails (~> 3.0.0)
   capybara
   compass-rails (~> 2.0.alpha.0)
   cucumber-rails

--- a/app/assets/javascripts/templates/search-item.hbs
+++ b/app/assets/javascripts/templates/search-item.hbs
@@ -2,7 +2,7 @@
 {{#unless item.more}}
 {{#unless item.none}}
 <div class="row">
-  <div class="span1">
+  <div class="col-md-1">
     {{#if item.thumbnail}}
       <img src="{{item.thumbnail}}" class="master-search-thumbnail"/>
     {{/if}}
@@ -11,7 +11,7 @@
     {{/unless}}
   </div>
 
-  <div class="span3">
+  <div class="col-md-3">
     <div>
       {{item.title}}
     </div>

--- a/app/assets/stylesheets/application.css.scss
+++ b/app/assets/stylesheets/application.css.scss
@@ -11,7 +11,6 @@
  *= require_self
  *= require_tree .
  *= require twitter/bootstrap
- *= require twitter/bootstrap/_responsive
  */
 
 @import "compass/css3/transition";

--- a/app/views/books/_book.html.haml
+++ b/app/views/books/_book.html.haml
@@ -1,11 +1,11 @@
 .book-block
   .row
-    .span1
+    .col-md-1
       - if book.google_book_data.img_thumbnail != ''
         = link_to image_tag(book.google_book_data.img_thumbnail), book
       - else
         = link_to "", book, class: "blank-thumbnail"
-    .span10
+    .col-md-10
       %h4
         = link_to book.title, book
       %h5

--- a/app/views/books/show.html.haml
+++ b/app/views/books/show.html.haml
@@ -8,7 +8,7 @@
 
 
 .row
-  .span2.text-center
+  .col-md-2.text-center
     - if @book.google_book_data.img_small != "" 
       %img{src: @book.google_book_data.img_small, class: "img-polaroid" }
     -else
@@ -37,7 +37,7 @@
               = f.hidden_field "book_id", value: @book.id
               = f.hidden_field "user_id", value: current_user.id
               = f.submit "Make Reservation", class: "btn btn-primary"
-  .span10
+  .col-md-10
     %dl.dl-horizontal
       %dt Authors
       %dd

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -21,9 +21,7 @@
         %input.form-control{ id: "master-search", type: "text", placeholder:"Search for a book...", "data-provide" => "typahead", autocomplete: "off", name:"search", autofocus: "autofocus"}
       .navbar-right
         -if user_signed_in?
-          %ul.nav
-            %li
-              =link_to current_user.email, user_path(current_user)
+          =link_to current_user.email, user_path(current_user)
           = link_to "Add Book", "/books/new", class: "btn btn-default navbar-btn"
           = link_to "Sign out", destroy_user_session_path, class: "btn btn-default navbar-btn", method: :delete
 

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -9,27 +9,26 @@
     %meta{ :name => 'viewport', :content => 'width=device-width, initial-scale=1.0' }
 
   %body
-    .nav.navbar.navbar-fixed-top
-      .navbar-inner
-        .container
-          %a.navbar-brand.visible-lg{ href: "/" }
-            =image_tag("logo.png", class: "logo", alt: "Alexandria logo")
-            Alexandria
-          %a.navbar-brand.hidden-lg{ href: "/" }
-            =image_tag("logo.png", class: "logo", alt: "Alexandria logo")
+    %nav.navbar.navbar-default.navbar-fixed-top
+      .navbar-header
+        %a.navbar-brand.visible-lg{ href: "/" }
+          =image_tag("logo.png", class: "logo", alt: "Alexandria logo")
+          Alexandria
+        %a.navbar-brand.hidden-lg{ href: "/" }
+          =image_tag("logo.png", class: "logo", alt: "Alexandria logo")
 
-          %form.navbar-search.pull-left{action: "/books"}
-            %input{ id: "master-search", type: "text", placeholder:"Search for a book...", "data-provide" => "typahead", autocomplete: "off", name:"search", autofocus: "autofocus"}
-          .pull-right
-            -if user_signed_in?
-              %ul.nav
-                %li
-                  =link_to current_user.email, user_path(current_user)
-              = link_to "Add Book", "/books/new", class: "btn btn-default"
-              = link_to "Sign out", destroy_user_session_path, class: "btn btn-default", method: :delete
+      %form.navbar-form.navbar-left{action: "/books"}
+        %input.form-control{ id: "master-search", type: "text", placeholder:"Search for a book...", "data-provide" => "typahead", autocomplete: "off", name:"search", autofocus: "autofocus"}
+      .navbar-right
+        -if user_signed_in?
+          %ul.nav
+            %li
+              =link_to current_user.email, user_path(current_user)
+          = link_to "Add Book", "/books/new", class: "btn btn-default navbar-btn"
+          = link_to "Sign out", destroy_user_session_path, class: "btn btn-default navbar-btn", method: :delete
 
-            -else
-              = link_to "Sign in", user_omniauth_authorize_path(:google_oauth2), class: "btn btn-default"
+        -else
+          = link_to "Sign in", user_omniauth_authorize_path(:google_oauth2), class: "btn btn-default navbar-btn"
 
     .container
       - if notice

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -10,23 +10,24 @@
 
   %body
     %nav.navbar.navbar-default.navbar-fixed-top
-      .navbar-header
-        %a.navbar-brand.visible-lg{ href: "/" }
-          =image_tag("logo.png", class: "logo", alt: "Alexandria logo")
-          Alexandria
-        %a.navbar-brand.hidden-lg{ href: "/" }
-          =image_tag("logo.png", class: "logo", alt: "Alexandria logo")
+      .container
+        .navbar-header
+          %a.navbar-brand.visible-lg{ href: "/" }
+            =image_tag("logo.png", class: "logo", alt: "Alexandria logo")
+            Alexandria
+          %a.navbar-brand.hidden-lg{ href: "/" }
+            =image_tag("logo.png", class: "logo", alt: "Alexandria logo")
 
-      %form.navbar-form.navbar-left{action: "/books"}
-        %input.form-control{ id: "master-search", type: "text", placeholder:"Search for a book...", "data-provide" => "typahead", autocomplete: "off", name:"search", autofocus: "autofocus"}
-      .navbar-right
-        -if user_signed_in?
-          =link_to current_user.email, user_path(current_user)
-          = link_to "Add Book", "/books/new", class: "btn btn-default navbar-btn"
-          = link_to "Sign out", destroy_user_session_path, class: "btn btn-default navbar-btn", method: :delete
+        %form.navbar-form.navbar-left{action: "/books"}
+          %input.form-control{ id: "master-search", type: "text", placeholder:"Search for a book...", "data-provide" => "typahead", autocomplete: "off", name:"search", autofocus: "autofocus"}
+        .navbar-right
+          -if user_signed_in?
+            =link_to current_user.email, user_path(current_user)
+            = link_to "Add Book", "/books/new", class: "btn btn-default navbar-btn"
+            = link_to "Sign out", destroy_user_session_path, class: "btn btn-default navbar-btn", method: :delete
 
-        -else
-          = link_to "Sign in", user_omniauth_authorize_path(:google_oauth2), class: "btn btn-default navbar-btn"
+          -else
+            = link_to "Sign in", user_omniauth_authorize_path(:google_oauth2), class: "btn btn-default navbar-btn"
 
     .container
       - if notice

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -12,10 +12,10 @@
     .nav.navbar.navbar-fixed-top
       .navbar-inner
         .container
-          %a.brand.visible-desktop{ href: "/" }
+          %a.navbar-brand.visible-lg{ href: "/" }
             =image_tag("logo.png", class: "logo", alt: "Alexandria logo")
             Alexandria
-          %a.brand.hidden-desktop{ href: "/" }
+          %a.navbar-brand.hidden-lg{ href: "/" }
             =image_tag("logo.png", class: "logo", alt: "Alexandria logo")
 
           %form.navbar-search.pull-left{action: "/books"}
@@ -25,11 +25,11 @@
               %ul.nav
                 %li
                   =link_to current_user.email, user_path(current_user)
-              = link_to "Add Book", "/books/new", class: "btn"
-              = link_to "Sign out", destroy_user_session_path, class: "btn", method: :delete
+              = link_to "Add Book", "/books/new", class: "btn btn-default"
+              = link_to "Sign out", destroy_user_session_path, class: "btn btn-default", method: :delete
 
             -else
-              = link_to "Sign in", user_omniauth_authorize_path(:google_oauth2), class: "btn"
+              = link_to "Sign in", user_omniauth_authorize_path(:google_oauth2), class: "btn btn-default"
 
     .container
       - if notice

--- a/app/views/root/index.html.haml
+++ b/app/views/root/index.html.haml
@@ -4,28 +4,28 @@
 
 .row
 	- @books.each do |book|
-		.span4
+		.col-md-4
 			.text-center
 				%h4
 					=link_to book.title, book
 				%i
 					%h5= book.subtitle
-				.row.visible-phone
+				.row.visible-sm
 					%br
 					%img{src: book.google_book_data.img_small, class: "img-polaroid"}
 					%hr
 
-.row.hidden-phone
+.row.hidden-sm
 	- @books.each do |book|
-		.span4
+		.col-md-4
 			.text-center
 				%br
 				= link_to book do
 					%img{src: book.google_book_data.img_small, class: "img-polaroid"}
 
-.row.hidden-phone
+.row.hidden-sm
 	- @books.each do |book|
-		.span4
+		.col-md-4
 			%br
 			%p= truncate(book.google_book_data.description, length: 500)
 


### PR DESCRIPTION
**Notes:**
- If sprockets fails or the styles look really messed up, you may need to delete your `tmp` directoy (the one in the Alexandria repo) and/or restart your Rails server.
- The typeahead plugin in Bootstrap 2 (that we are currently using) is now removed in Bootstrap 3. We will need to transition to [typeahead.js](https://github.com/twitter/typeahead.js), which I did not do yet.
- I am currently using `col-md-*` for all of our column tiers. We may want to use different tiers in different places in the future.
