### PR TITLE
Settings initializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Get started
 7. Start solr: `rake sunspot:solr:start`
 8. Start server: `rails s`
 
+Settings
+--------
+Library-specific settings can be configured in `config/initializers/settings.rb`.
+
 Solr
 ----
 Solr is the search engine tool used in Alexandria. Once it is running, it will automatically index newly created book entries, but existing entries that are not indexed are ignored. Index entries manually by running `rake sunspot:reindex`.

--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -15,7 +15,7 @@ class Checkout < ActiveRecord::Base
 
   def default_values
     self.checked_out_at ||= DateTime.now
-    self.due_date ||= checked_out_at + 1.week
+    self.due_date ||= checked_out_at + Rails.configuration.checkout_period
   end
 
   def patron(who = nil)
@@ -68,7 +68,7 @@ class Checkout < ActiveRecord::Base
 
   def send_overdue
     if overdue?
-      self.due_date += 1.week
+      self.due_date += Rails.configuration.checkout_period
       save
       strike = Strike.new
       strike.patron = patron

--- a/app/models/checkout.rb
+++ b/app/models/checkout.rb
@@ -63,7 +63,7 @@ class Checkout < ActiveRecord::Base
   end
 
   def need_reminding?
-    Date.today + 3.days == self.due_date.to_date && checked_in_at.blank?
+    Date.today + Rails.configuration.remind_before == self.due_date.to_date && checked_in_at.blank?
   end
 
   def send_overdue

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -11,7 +11,7 @@ class Reservation < ActiveRecord::Base
   validate :cannot_have_2_reservations_on_1_book
 
   def default_values
-    self.expires_at ||= DateTime.now + 1.week
+    self.expires_at ||= DateTime.now + Rails.configuration.reservation_period
     self.fulfilled ||= false
     self.reserve_at ||= DateTime.now
   end

--- a/app/views/checkout_mailer/reminder.html.haml
+++ b/app/views/checkout_mailer/reminder.html.haml
@@ -9,7 +9,7 @@
       We would like to inform you that the book you have checked out,
       %b
         = @book.title
-      , is due in 3 days.
+      , is due in #{pluralize(Rails.configuration.remind_before, 'day')}.
       If you don't return this book by
       %b
         = @checkout.due_date.strftime('%B %d, %Y')

--- a/app/views/checkout_mailer/reminder.text.haml
+++ b/app/views/checkout_mailer/reminder.text.haml
@@ -2,7 +2,8 @@
 \
 We would like to inform you that the book you have checked out,
 = @book.title
-, is due in 3 days. If you don't return this book by
+, is due in #{pluralize(Rails.configuration.remind_before, 'day')}. If you don't
+return this book by
 = @checkout.due_date.strftime('%B %d, %Y')
 you will recieve a strike. It you need to keep the book longer than that, please
 stop by to renew the book.

--- a/config/initializers/settings.rb
+++ b/config/initializers/settings.rb
@@ -1,10 +1,26 @@
+# This file contains configuration options for the Alexandria library itself.
 # Be sure to restart your server when you modify this file.
 
+# The time before a reservation expires.
 Rails.configuration.reservation_period = 1.week
-Rails.configuration.checkout_period    = 1.week
-Rails.configuration.remind_before      = 3.days
-Rails.configuration.strikes_for_ban    = 3
 
+# The time before a checkout is due.
+Rails.configuration.checkout_period = 1.week
+
+# The time before a checkout is due when an email warning should be sent to the
+# appropriate patron.
+Rails.configuration.remind_before = 3.days
+
+# The number of strikes a user must have to be automatically banned.
+#
+# TODO: Start using this setting in the application.
+Rails.configuration.strikes_for_ban = 3
+
+# The configuration of shelves in the physical library. Only the first and last
+# book codes of each shelf need to be stored here.
+#
 # TODO: Replace this with an Array of Ranges of Strings. Each Range should
 # represent the first and last book codes for the given shelf.
+#
+# TODO: Start using this setting in the application.
 Rails.configuration.shelves = []

--- a/config/initializers/settings.rb
+++ b/config/initializers/settings.rb
@@ -2,3 +2,4 @@
 
 Rails.configuration.reservation_period = 1.week
 Rails.configuration.checkout_period    = 1.week
+Rails.configuration.remind_before      = 3.days

--- a/config/initializers/settings.rb
+++ b/config/initializers/settings.rb
@@ -4,3 +4,7 @@ Rails.configuration.reservation_period = 1.week
 Rails.configuration.checkout_period    = 1.week
 Rails.configuration.remind_before      = 3.days
 Rails.configuration.strikes_for_ban    = 3
+
+# TODO: Replace this with an Array of Ranges of Strings. Each Range should
+# represent the first and last book codes for the given shelf.
+Rails.configuration.shelves = []

--- a/config/initializers/settings.rb
+++ b/config/initializers/settings.rb
@@ -1,26 +1,28 @@
-# This file contains configuration options for the Alexandria library itself.
-# Be sure to restart your server when you modify this file.
+Alexandria::Application.configure do
+  # This file contains configuration options for the Alexandria library itself.
+  # Be sure to restart your server when you modify this file.
 
-# The time before a reservation expires.
-Rails.configuration.reservation_period = 1.week
+  # The time before a reservation expires.
+  config.reservation_period = 1.week
 
-# The time before a checkout is due.
-Rails.configuration.checkout_period = 1.week
+  # The time before a checkout is due.
+  config.checkout_period = 1.week
 
-# The time before a checkout is due when an email warning should be sent to the
-# appropriate patron.
-Rails.configuration.remind_before = 3.days
+  # The time before a checkout is due when an email warning should be sent to the
+  # appropriate patron.
+  config.remind_before = 3.days
 
-# The number of strikes a user must have to be automatically banned.
-#
-# TODO: Start using this setting in the application.
-Rails.configuration.strikes_for_ban = 3
+  # The number of strikes a user must have to be automatically banned.
+  #
+  # TODO: Start using this setting in the application.
+  config.strikes_for_ban = 3
 
-# The configuration of shelves in the physical library. Only the first and last
-# book codes of each shelf need to be stored here.
-#
-# TODO: Replace this with an Array of Ranges of Strings. Each Range should
-# represent the first and last book codes for the given shelf.
-#
-# TODO: Start using this setting in the application.
-Rails.configuration.shelves = []
+  # The configuration of shelves in the physical library. Only the first and last
+  # book codes of each shelf need to be stored here.
+  #
+  # TODO: Replace this with an Array of Ranges of Strings. Each Range should
+  # represent the first and last book codes for the given shelf.
+  #
+  # TODO: Start using this setting in the application.
+  config.shelves = []
+end

--- a/config/initializers/settings.rb
+++ b/config/initializers/settings.rb
@@ -1,0 +1,4 @@
+# Be sure to restart your server when you modify this file.
+
+Rails.configuration.reservation_period = 1.week
+Rails.configuration.checkout_period    = 1.week

--- a/config/initializers/settings.rb
+++ b/config/initializers/settings.rb
@@ -3,3 +3,4 @@
 Rails.configuration.reservation_period = 1.week
 Rails.configuration.checkout_period    = 1.week
 Rails.configuration.remind_before      = 3.days
+Rails.configuration.strikes_for_ban    = 3

--- a/spec/mailers/checkout_mailer_spec.rb
+++ b/spec/mailers/checkout_mailer_spec.rb
@@ -6,7 +6,7 @@ describe CheckoutMailer, solr: true do
   let(:checkout) do
     Checkout.new(
                 checked_out_at: Date.today,
-                due_date: Date.today + 1.week,
+                due_date: Date.today + Rails.configuration.checkout_period,
                 book_id: book.id,
                 patron_id: user.id
               )

--- a/spec/models/checkout_spec.rb
+++ b/spec/models/checkout_spec.rb
@@ -19,8 +19,8 @@ describe Checkout, solr: true do
     expect(@checkout.patron).to eq(user)
   end
 
-  it 'has a due date of a week after' do
-    expect(@checkout.due_date).to eq(@checkout.checked_out_at + 1.week)
+  it 'has a due date at the appropriate time' do
+    expect(@checkout.due_date).to eq(@checkout.checked_out_at + Rails.configuration.checkout_period)
   end
 
   it 'can be found given book and patron' do

--- a/spec/models/checkout_spec.rb
+++ b/spec/models/checkout_spec.rb
@@ -62,14 +62,14 @@ describe Checkout, solr: true do
   end
 
   describe 'needing reminding' do
-    it 'needs reminding if 3 days until duedate' do
+    it 'needs reminding if at the appropriate time until duedate' do
       expect(@checkout.need_reminding?).to be_false
-      @checkout.due_date = Date.today + 3.days
+      @checkout.due_date = Date.today + Rails.configuration.remind_before
       expect(@checkout.need_reminding?).to be_true
     end
 
     it 'should not need reminding if already checked in' do
-      @checkout.due_date = Date.today + 3.days
+      @checkout.due_date = Date.today + Rails.configuration.remind_before
       @checkout.checked_in_at = DateTime.now
       expect(@checkout.need_reminding?).to be_false
     end
@@ -77,7 +77,7 @@ describe Checkout, solr: true do
     it 'should send an email' do
       @checkout.book = book
       @checkout.patron = user
-      @checkout.due_date = Date.today + 3.days
+      @checkout.due_date = Date.today + Rails.configuration.remind_before
       @checkout.send_reminder
       expect(ActionMailer::Base.deliveries.last.to).to include(user.email)
       expect(ActionMailer::Base.deliveries.last.subject).to eq('You have a book due soon.')


### PR DESCRIPTION
## Notes
- There are no default values besides the ones currently in the initializer file, so none of the settings can be removed.
- `strikes_for_ban` and `shelves` are not used in the application yet.
- The application must be restarted to change these settings (though you could theoretically change them at runtime with `rails console`).
- We might want to test changing the settings in our specs (especially since some settings share the same default values).
