### PR TITLE
Test on Ruby 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: ruby
 rvm:
   - 2.0.0
+  - 2.1.0
 before_install:
   - sudo apt-get install yaz libyaz4-dev


### PR DESCRIPTION
Ruby 2.1 is out, so we might as well add that to our Travis test suite.

**Advantage:** Helps ensure that Alexandria won't break when we use Ruby 2.1 in production.
**Disadvantage:** We'll be testing on two versions of Ruby instead of just one, so our Travis builds might take longer.

@kristenmills
